### PR TITLE
Remove type tagging of command line arguments

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 recursive-include src *.py
 include README.md
+global-include *.typed
+global-include *.pyi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = argsubparse
-version = 0.0.7
+version = 0.0.8
 author = Jordan Woods
 author_email = jor.e.woods@gmail.com
 description = Dynamically build argparse subparsers
@@ -19,6 +19,10 @@ package_dir =
     = src
 packages = find:
 python_requires = >=3.6
+
+[options.package_data]
+argsubparse =
+    py.typed
 
 [options.packages.find]
 where = src

--- a/src/argsubparse/argsubparse.py
+++ b/src/argsubparse/argsubparse.py
@@ -80,8 +80,6 @@ def create_subparser(
                     short_option = f"-{short_option}"
                 arg_name = (short_option, f"--{k}")
 
-        if v.annotation is not inspect._empty:
-            arg_params["type"] = v.annotation
         function_parser.add_argument(*arg_name, **arg_params)
 
     usage = [parser.usage, func.__doc__]


### PR DESCRIPTION
Not all types are able to be passed into argparse. More work will be required to ensure that only relevant types get passed.